### PR TITLE
Refactor environment variable loading and logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,5 @@ data/output/
 .DS_Store
 
 data/input/
+
+local_setup/*.env

--- a/CHANGELOGS.MD
+++ b/CHANGELOGS.MD
@@ -1,3 +1,14 @@
+## [2025-07-27] Refactor and Environment-based Configuration
+
+### Changed
+- Refactored `py-ollama.py` and `generate_explanation.py` to load configuration values (model, input/output/log directories, prompt template) from environment variables using `local_setup/config.env`.
+- Updated `Config` dataclass initialization to use `os.getenv` for all configurable parameters, improving flexibility and consistency.
+- Standardized use of `Path` objects for file and directory paths after loading from environment variables.
+- Moved reusable response statistics logging to `src/utils/logging.py` and imported it where needed.
+- Centralized logging configuration in the logging utility module.
+- Added error handling for file operations and OCR failures.
+- Updated Makefile and run instructions to support environment-
+
 ## [2025-07-26] Image Processing and Model Integration
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,8 @@ clean-log: # Clean up log files.
 run-processing-image: # Run the Python script.
 	$(MAKE) clean-log
 	@echo "Running the Python script..."
-	@python3 ./src/image_processing/py-ollama.py
+	@python -m src.image_processing.py-ollama
+
+run-generate-explanation: # Run the Python script.
+	@echo "Running the Python script..."
+	@python -m src.image_processing.generate_explanation

--- a/local_setup/config.env.template
+++ b/local_setup/config.env.template
@@ -1,0 +1,10 @@
+OLAMA_MODEL=gemma3:1b
+OLAMA_INPUT_DIR=./data/input
+OLAMA_LOG_DIR=./data/output/logs
+OLAMA_OUTPUT_FILE=./data/output/aggregated/questions.md
+OLAMA_PROMPT_TEMPLATE=template_image_to_text
+
+EXPLAIN_INPUT_FILE=./data/output/aggregated/questions.md
+EXPLAIN_OUTPUT_FILE=./data/output/aggregated/explanations.md
+EXPLAIN_MODEL=gemma3:12b
+EXPLAIN_INSTRUCTION_FILE=./prompts/explain_spark_answer.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ manimgl==1.7.2
 pytesseract==0.3.13
 pillow==11.3.0
 ollama==0.5.1
+python-dotenv==1.1.1

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -1,0 +1,15 @@
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s"
+)
+
+def log_response_stats(response):
+    """Log statistics from an Ollama model response."""
+    logging.info(f"Inference Time (ms): {response.total_duration / 1_000_000:.2f}")
+    logging.info(f"Prompt Tokens: {response.prompt_eval_count}")
+    logging.info(f"Response Tokens: {response.eval_count}")
+    if response.total_duration > 0:
+        rps = response.eval_count / (response.total_duration / 1_000_000_000)  # ns to s
+        logging.info(f"Response Speed: {rps:.2f} tokens/sec")


### PR DESCRIPTION
### Changed
- Refactored `py-ollama.py` and `generate_explanation.py` to load configuration values (model, input/output/log directories, prompt template) from environment variables using `local_setup/config.env`.
- Updated `Config` dataclass initialization to use `os.getenv` for all configurable parameters, improving flexibility and consistency.
- Standardized use of `Path` objects for file and directory paths after loading from environment variables.
- Moved reusable response statistics logging to `src/utils/logging.py` and imported it where needed.
- Centralized logging configuration in the logging utility module.
- Added error handling for file operations and OCR failures.
- Updated Makefile and run instructions to support environment-based configuration.